### PR TITLE
AWS Lambda 実行ファイル名修正

### DIFF
--- a/esbuild.config.mjs
+++ b/esbuild.config.mjs
@@ -22,7 +22,7 @@ await esbuild
         entryPoints: ['src/handlers/aws/serverless.ts'],
         minify     : true,
         bundle     : true,
-        outfile    : 'dist/aws-serverless.mjs',
+        outfile    : 'dist/index.mjs',
         format     : 'esm',
         platform   : 'node',
         define,

--- a/package.json
+++ b/package.json
@@ -5,7 +5,7 @@
   "type": "module",
   "scripts": {
     "main": "tsx src/handlers/main.ts",
-    "aws-serverless": "node esbuild.config.mjs && cd dist && zip upload.zip aws-serverless.mjs",
+    "aws-serverless": "node esbuild.config.mjs && cd dist && zip upload.zip index.mjs",
     "lint": "eslint .",
     "lint:fix": "eslint . --fix",
     "test": "tsc --noEmit && vitest --run",


### PR DESCRIPTION
AWS Lambdaのデフォルト実行エントリーポイント名が `index.mjs` っぽいので、それに合わせただけ。